### PR TITLE
1.1 - Compatibility with Gradle 4.3

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
         // Gradle API
         // Original: https://github.com/remal-gradle-api/packages/packages/760197?version=7.0.2
         // Mirror:   https://repos.moddinglegacy.com/#/modding-legacy/name/remal/gradle-api/gradle-api/7.0.2
-        version 'gradle', '5.1'
+        version 'gradle', '4.3'
         library 'gradle', 'name.remal.gradle-api', 'gradle-api'  versionRef 'gradle'
     }
 }


### PR DESCRIPTION
This PR ensures that GradleJarSigner is backwards compatible with Gradle 4.3. This was done as part of an ongoing effort to get Minecraft Forge 1.13 - 1.15 building again.

- Depends on #1.
- This PR will be rebased once dependent PRs are merged.
  - See the specific commit for the proper diff.